### PR TITLE
Fix policy resource

### DIFF
--- a/jamf/data_source_jamf_policy.go
+++ b/jamf/data_source_jamf_policy.go
@@ -714,7 +714,6 @@ func deconstructJamfPolicyStruct(d *schema.ResourceData, in *jamf.Policy) {
 				"distribution_point": in.General.OverrideDefaultSettings.DistributionPoint,
 				"force_afp_smb":      in.General.OverrideDefaultSettings.ForceAfpSmb,
 				"sus":                in.General.OverrideDefaultSettings.Sus,
-				"netboot_server":     in.General.OverrideDefaultSettings.NetbootServer,
 			},
 		}
 	}

--- a/jamf/resource_jamf_policy.go
+++ b/jamf/resource_jamf_policy.go
@@ -230,11 +230,6 @@ func resourceJamfPolicy() *schema.Resource {
 										Optional: true,
 										Default:  "default",
 									},
-									"netboot_server": {
-										Type:     schema.TypeString,
-										Optional: true,
-										Default:  "current",
-									},
 								},
 							},
 						},
@@ -817,9 +812,6 @@ func buildJamfPolicyStruct(d *schema.ResourceData) *jamf.Policy {
 			}
 			if val, ok := overrideDefaultSettings["sus"].(string); ok {
 				out.General.OverrideDefaultSettings.Sus = val
-			}
-			if val, ok := overrideDefaultSettings["netboot_server"].(string); ok {
-				out.General.OverrideDefaultSettings.NetbootServer = val
 			}
 		}
 

--- a/jamf/resource_jamf_policy.go
+++ b/jamf/resource_jamf_policy.go
@@ -214,11 +214,12 @@ func resourceJamfPolicy() *schema.Resource {
 									"target_drive": {
 										Type:     schema.TypeString,
 										Optional: true,
-										Default:  "default",
+										Default:  "/",
 									},
 									"distribution_point": {
 										Type:     schema.TypeString,
 										Optional: true,
+										Default:  "default",
 									},
 									"force_afp_smb": {
 										Type:     schema.TypeBool,
@@ -413,10 +414,12 @@ func resourceJamfPolicy() *schema.Resource {
 									"display_in": {
 										Type:     schema.TypeBool,
 										Optional: true,
+										Default:  true,
 									},
 									"feature_in": {
 										Type:     schema.TypeBool,
 										Optional: true,
+										Default:  false,
 									},
 								},
 							},
@@ -546,10 +549,12 @@ func resourceJamfPolicy() *schema.Resource {
 						"start_reboot_timer_immediately": {
 							Type:     schema.TypeBool,
 							Optional: true,
+							Default:  false,
 						},
 						"file_vault_2_reboot": {
 							Type:     schema.TypeBool,
 							Optional: true,
+							Default:  false,
 						},
 					},
 				},

--- a/website/docs/r/policy.html.md
+++ b/website/docs/r/policy.html.md
@@ -69,8 +69,8 @@ The following arguments are supported:
     * `any_ip_address`              - (Optional) IP Address range required, Default `true`
     * `network_segments`            - (Optional) Network Segments required
   * `override_default_settings` - (Required) Default settings of the policy to override
-    * `target_drive`                - (Optional) Default target installation drive, Default `default`
-    * `distribution_point`          - (Optional) Default distribution point
+    * `target_drive`                - (Optional) Default target installation drive, Default `/`
+    * `distribution_point`          - (Optional) Default distribution point, Default `default`
     * `force_afp_smb`               - (Optional) ?
     * `sus`                         - (Optional) ?, Default `default`
   * `site`                      - (Required) Site of the policy
@@ -95,10 +95,10 @@ The following arguments are supported:
   * `feature_on_main_page`          - (Optional) State of main page featuring
   * `self_service_icon`             - (Required) Self Service icon configuration
     * `id`                              - (Optional) ID of the icon, Default `0`
-  * `self_service_category`         - (Optional) Self Service category configuration
-    * `id`                              - (Optional) ID of the category, if policy category is defined this will be need to be set to same category ID
-    * `display_in`                      - (Optional) Display state in the category
-    * `feature_in`                      - (Optional) Feature state in the category
+  * `self_service_category`         - (Optional) Self Service category configuration and this block can have multiple settings, if the policy category is defined this will need to be set to the same category at least one
+    * `id`                              - (Optional) ID of the category
+    * `display_in`                      - (Optional) Display state in the category, Default `true`
+    * `feature_in`                      - (Optional) Feature state in the category, Default `false`
 * `package`                     - (Optional) Package information assigned to the policy
   * `id`                            - (Required) ID of the package
   * `action`                        - (Optional) Action of the package, Default `INSTALL`
@@ -120,12 +120,12 @@ The following arguments are supported:
 * `reboot`                      - (Required) Reboot information assigned to the policy
   * `message`                       - (Optional) User message
   * `startup_disk`                  - (Optional) Startup disk after reboot, Default `Current Startup Disk`
-  * `specify_startup`               - (Optional) ?
+  * `specify_startup`               - (Optional) Local startup disk to boot computers when startup disk is `Specify Local Startup Disk`
   * `no_user_logged_in`             - (Optional) No user logged in functionality of the reboot, Default `Do not restart`
   * `user_logged_in`                - (Optional) User logged in functionality of the reboot, Default `Do not restart`
   * `minutes_until_reboot`          - (Optional) Minutes until the reboot triggers after reboot, Default `5`
-  * `start_reboot_timer_immediately`- (Optional) Reboot timer immediate state
-  * `file_vault_2_reboot`           - (Optional) ?
+  * `start_reboot_timer_immediately`- (Optional) Reboot timer immediate state, Default `false`
+  * `file_vault_2_reboot`           - (Optional) Restart FileVault 2-encrypted computers without requiring an unlock during the next startup, Default `false`
 * `maintenance`                 - (Optional) Maintenance information assigned to the policy
   * `recon`                         - (Optional) Recon state after policy completes
   * `reset_name`                    - (Optional) Reset name state

--- a/website/docs/r/policy.html.md
+++ b/website/docs/r/policy.html.md
@@ -73,7 +73,6 @@ The following arguments are supported:
     * `distribution_point`          - (Optional) Default distribution point
     * `force_afp_smb`               - (Optional) ?
     * `sus`                         - (Optional) ?, Default `default`
-    * `netboot_server`              - (Optional) ?, Default `current`
   * `site`                      - (Required) Site of the policy
     * `id`                          - (Optional) ID of the site, Default `-1`
 * `scope`                       - (Required) Scope of the policy


### PR DESCRIPTION
## Description

### Drop the netboot_server of override_default_settings in policy

The attribute netboot_server in override_default_settings in policy does not exist as a Jamf API strict.
I have therefore removed the relevant attribute.

<img width="683" alt="スクリーンショット 2023-02-27 2 03 12" src="https://user-images.githubusercontent.com/1155067/221425053-3f0ed4e7-a256-44e4-9b57-4b59b313dca4.png">

Ref: https://developer.jamf.com/jamf-pro/reference/findpoliciesbyid

### Some objects in policy have different default values, corrected

When we run `terraform plan` against the policy, we may get differences every time.

```terraform
resource "jamf_category" "category1" {
  name     = "category1"
  priority = 9
}

resource "jamf_category" "category2" {
  name    = "category2"
  priority = 9
}

resource "jamf_policy" "test" {
  general {
    name      = "[terraform] Test Policy 1"
    enabled   = true
    frequency = "Ongoing"

    category {
      id   = jamf_category.category1.id
      name = jamf_category.category1.name
    }
    network_limitations {}
    override_default_settings {}
    site {}
  }

  self_service {
    self_service_category {
      id = jamf_category.category1.id
    }
    self_service_category {
      id = jamf_category.category2.id
    }
    self_service_icon {}
  }

  scope {}
  reboot {}
}
```

The cause of this phenomenon is that the default values are different from those expected by this provider.
The response of Jamf API at this time is as follows

```json
{
  "policy": {
    "general": {
      "id": 54,
      "name": "[terraform] Test Policy 1",
      "enabled": true,
      "trigger": "EVENT",
      "trigger_checkin": false,
      "trigger_enrollment_complete": false,
      "trigger_login": false,
      "trigger_network_state_changed": false,
      "trigger_startup": false,
      "trigger_other": "",
      "frequency": "Ongoing",
      "retry_event": "none",
      "retry_attempts": -1,
      "notify_on_each_failed_retry": false,
      "location_user_only": false,
      "target_drive": "/",
      "offline": false,
      "category": {
        "id": 16,
        "name": "category1"
      },
      "date_time_limitations": {
        "activation_date": "",
        "activation_date_epoch": 0,
        "activation_date_utc": "",
        "expiration_date": "",
        "expiration_date_epoch": 0,
        "expiration_date_utc": "",
        "no_execute_on": {},
        "no_execute_start": "",
        "no_execute_end": ""
      },
      "network_limitations": {
        "minimum_network_connection": "No Minimum",
        "any_ip_address": true,
        "network_segments": []
      },
      "override_default_settings": {
        "target_drive": "/",
        "distribution_point": "default",
        "force_afp_smb": false,
        "sus": "default"
      },
      "network_requirements": "Any",
      "site": {
        "id": -1,
        "name": "None"
      }
    },
    "scope": {
      "all_computers": true,
      "computers": [],
      "computer_groups": [],
      "buildings": [],
      "departments": [],
      "limit_to_users": {
        "user_groups": []
      },
      "limitations": {
        "users": [],
        "user_groups": [],
        "network_segments": [],
        "ibeacons": []
      },
      "exclusions": {
        "computers": [],
        "computer_groups": [],
        "buildings": [],
        "departments": [],
        "users": [],
        "user_groups": [],
        "network_segments": [],
        "ibeacons": []
      }
    },
    "self_service": {
      "use_for_self_service": false,
      "self_service_display_name": "",
      "install_button_text": "Install",
      "reinstall_button_text": "Reinstall",
      "self_service_description": "",
      "force_users_to_view_description": false,
      "self_service_icon": {},
      "feature_on_main_page": false,
      "self_service_categories": [
        {
          "id": 16,
          "name": "category1",
          "display_in": true,
          "feature_in": false
        },
        {
          "id": 17,
          "name": "category2",
          "display_in": true,
          "feature_in": false
        }
      ],
      "notification": "Self Service",
      "notification_subject": "",
      "notification_message": ""
    },
    "package_configuration": {
      "packages": [],
      "distribution_point": "default"
    },
    "scripts": [],
    "printers": [
      ""
    ],
    "dock_items": [],
    "account_maintenance": {
      "accounts": [],
      "directory_bindings": [],
      "management_account": {
        "action": "doNotChange"
      },
      "open_firmware_efi_password": {
        "of_mode": "none",
        "of_password_sha256": ""
      }
    },
    "reboot": {
      "message": "",
      "startup_disk": "Current Startup Disk",
      "specify_startup": "",
      "no_user_logged_in": "Do not restart",
      "user_logged_in": "Do not restart",
      "minutes_until_reboot": 5,
      "start_reboot_timer_immediately": false,
      "file_vault_2_reboot": false
    },
    "maintenance": {
      "recon": false,
      "reset_name": false,
      "install_all_cached_packages": false,
      "heal": false,
      "prebindings": false,
      "permissions": false,
      "byhost": false,
      "system_cache": false,
      "user_cache": false,
      "verify": false
    },
    "files_processes": {
      "search_by_path": "",
      "delete_file": false,
      "locate_file": "",
      "update_locate_database": false,
      "spotlight_search": "",
      "search_for_process": "",
      "kill_process": false,
      "run_command": ""
    },
    "user_interaction": {
      "message_start": "",
      "allow_users_to_defer": false,
      "allow_deferral_until_utc": "",
      "allow_deferral_minutes": 0,
      "message_finish": ""
    },
    "disk_encryption": {
      "action": "none"
    }
  }
}
```

Therefore, to the best of my knowledge and influence, I have modified the default values of the `jamf_policy` resource.