### PR TITLE
Implemented support for Jamf OAuth API Clients

### DIFF
--- a/jamf/provider.go
+++ b/jamf/provider.go
@@ -27,6 +27,16 @@ func Provider() *schema.Provider {
 				Optional:    true,
 				DefaultFunc: schema.MultiEnvDefaultFunc([]string{"JAMF_PASSWORD"}, nil),
 			},
+			"client_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.MultiEnvDefaultFunc([]string{"JAMF_CLIENT_ID"}, nil),
+			},
+			"client_secret": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.MultiEnvDefaultFunc([]string{"JAMF_CLIENT_SECRET"}, nil),
+			},
 			"url": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -67,7 +77,14 @@ func Provider() *schema.Provider {
 
 func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
 	var diags diag.Diagnostics
-	c, err := jamf.NewClient(d.Get("username").(string), d.Get("password").(string), d.Get("url").(string))
+	var c *jamf.Client
+	var err error
+	_, OAuth := d.GetOk("client_id")
+	if OAuth {
+		c, err = jamf.NewOAuthClient(d.Get("client_id").(string), d.Get("client_secret").(string), d.Get("url").(string))
+	} else {
+		c, err = jamf.NewClient(d.Get("username").(string), d.Get("password").(string), d.Get("url").(string))
+	}
 	if err != nil {
 		diag.FromErr(err)
 	}

--- a/jamf/provider_test.go
+++ b/jamf/provider_test.go
@@ -27,6 +27,12 @@ func testAccPreCheck(t *testing.T) {
 	if !isURLSet() {
 		t.Fatal("JAMF_URL environment variable must be set for acceptance tests")
 	}
+	if !isClientIdSet() {
+		t.Fatal("JAMF_CLIENT_ID environment variable must be set for acceptance tests")
+	}
+	if !isClientSecretSet() {
+		t.Fatal("JAMF_CLIENT_SECRET environment variable must be set for acceptance tests")
+	}
 }
 
 func isUsernameSet() bool {
@@ -45,6 +51,20 @@ func isPasswordSet() bool {
 
 func isURLSet() bool {
 	if os.Getenv("JAMF_URL") != "" {
+		return true
+	}
+	return false
+}
+
+func isClientIdSet() bool {
+	if os.Getenv("JAMF_CLIENT_ID") != "" {
+		return true
+	}
+	return false
+}
+
+func isClientSecretSet() bool {
+	if os.Getenv("JAMF_CLIENT_SECRET") != "" {
 		return true
 	}
 	return false

--- a/website/docs/index.html.md
+++ b/website/docs/index.html.md
@@ -67,10 +67,27 @@ provider "jamf" {
 }
 ```
 
+Starting with Jamf Pro 10.49, you can alternatively provide a client ID and 
+client secret from the 
+["API Roles and Clients"](https://learn.jamf.com/bundle/jamf-pro-documentation-10.49.0/page/API_Roles_and_Clients.html) 
+section of Jamf Pro preferences.
+
+Usage:
+
+```hcl
+provider "jamf" {
+    client_id = "xxxx"
+    client_secret = "xxxx"
+
+    # "This is the xxxx part of xxxx.jamfcloud.com"
+    url = "xxxx"
+}
+```
+
 ### Environment Variables
 
-You can provide your credentials via the `JAMF_USERNAME`, `JAMF_PASSWORD` and
-`JAMF_URL`, environment variables.
+You can provide your credentials via the `JAMF_USERNAME`, `JAMF_PASSWORD`, `JAMF_CLIENT_ID`, `JAMF_CLIENT_SECRET`, and
+`JAMF_URL` environment variables.
 
 ```hcl
 provider "jamf" {}
@@ -85,6 +102,17 @@ $ export JAMF_URL="xxxx"
 $ terraform plan
 ```
 
+Or, with API Clients (Jamf Pro 10.49+):
+
+Usage:
+
+```sh
+$ export JAMF_CLIENT_ID="xxxx"
+$ export JAMF_CLIENT_SECRET="xxxx"
+$ export JAMF_URL="xxxx"
+$ terraform plan
+```
+
 ## Argument Reference
 
 In addition to [generic `provider` arguments](https://www.terraform.io/docs/configuration/providers.html)
@@ -94,5 +122,9 @@ In addition to [generic `provider` arguments](https://www.terraform.io/docs/conf
 * `username` - (Optional) This is the Jamf username.
 
 * `password` - (Optional) This is the Jamf user password.
+
+* `client_id` - (Optional) This is the Jamf API client ID.
+
+* `client_secret` - (Optional) This is the Jamf API client secret.
 
 * `url` - (Optional) This is the Jamf server url.


### PR DESCRIPTION
This PR adds support for API Clients, as introduced in [Jamf 10.49](https://learn.jamf.com/bundle/jamf-pro-documentation-10.49.0/page/API_Roles_and_Clients.html).

A client ID and a client secret can be provided either via the `client_id` and `client_secret` provider variables, or via the `JAMF_CLIENT_ID` and `JAMF_CLIENT_SECRET` environment variables.

This PR relies on [another PR for go-jamf-api](https://github.com/Yohan460/go-jamf-api/pull/15) being merged.