### PR TITLE
Assign computers to jamf_staticComputerGroups with serial_number or id + half a fix for jamf_computerExtensionAttribute tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,4 +52,4 @@ testacc: fmtcheck
 	TF_ACC=1 go test ./jamf -v -count 1 -parallel 20 $(TESTARGS) -timeout 120m
 
 fmtcheck:
-	@sh -c "'$(CURDIR)/scripts/gofmtcheck.sh'"
+	@sh -c "'$(CURDIR)/website/docs/scripts/gofmtcheck.sh'"

--- a/jamf/data_source_jamf_computer_extension_attribute.go
+++ b/jamf/data_source_jamf_computer_extension_attribute.go
@@ -38,6 +38,12 @@ func dataSourceJamfComputerExtensionAttribute() *schema.Resource {
 				Default:      "Extension Attributes",
 				ValidateFunc: validation.StringInSlice([]string{"General", "Hardware", "Operating System", "User and Location", "Purchasing", "Extension Attributes"}, false),
 			},
+			"recon_display": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "Extension Attributes",
+				ValidateFunc: validation.StringInSlice([]string{"General", "Hardware", "Operating System", "User and Location", "Purchasing", "Extension Attributes"}, false),
+			},
 			"script": {
 				Type:         schema.TypeList,
 				Optional:     true,

--- a/jamf/data_source_jamf_computer_extension_attribute.go
+++ b/jamf/data_source_jamf_computer_extension_attribute.go
@@ -41,7 +41,6 @@ func dataSourceJamfComputerExtensionAttribute() *schema.Resource {
 			"recon_display": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				Default:      "Extension Attributes",
 				ValidateFunc: validation.StringInSlice([]string{"General", "Hardware", "Operating System", "User and Location", "Purchasing", "Extension Attributes"}, false),
 			},
 			"script": {

--- a/jamf/resource_jamf_computer_extension_attribute.go
+++ b/jamf/resource_jamf_computer_extension_attribute.go
@@ -45,6 +45,12 @@ func resourceJamfComputerExtensionAttribute() *schema.Resource {
 				Default:      "Extension Attributes",
 				ValidateFunc: validation.StringInSlice([]string{"General", "Hardware", "Operating System", "User and Location", "Purchasing", "Extension Attributes"}, false),
 			},
+			"recon_display": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "Extension Attributes",
+				ValidateFunc: validation.StringInSlice([]string{"General", "Hardware", "Operating System", "User and Location", "Purchasing", "Extension Attributes"}, false),
+			},
 			"script": {
 				Type:         schema.TypeList,
 				Optional:     true,

--- a/jamf/resource_jamf_computer_extension_attribute.go
+++ b/jamf/resource_jamf_computer_extension_attribute.go
@@ -48,7 +48,6 @@ func resourceJamfComputerExtensionAttribute() *schema.Resource {
 			"recon_display": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				Default:      "Extension Attributes",
 				ValidateFunc: validation.StringInSlice([]string{"General", "Hardware", "Operating System", "User and Location", "Purchasing", "Extension Attributes"}, false),
 			},
 			"script": {

--- a/jamf/resource_jamf_computer_extension_attribute_test.go
+++ b/jamf/resource_jamf_computer_extension_attribute_test.go
@@ -39,7 +39,7 @@ const (
 	testAccCheckJamfComputerExtensionAttributeScript = `resource "jamf_computer_extension_attribute" "extensionattribute-script" {
 		name = "Terraform test script"
 		description = "testing jamf extension attribute resource"
-		data_type = "string"
+		data_type = "String"
 		inventory_display = "Extension Attributes" 
 
 		script {

--- a/jamf/resource_jamf_staticComputerGroup.go
+++ b/jamf/resource_jamf_staticComputerGroup.go
@@ -92,18 +92,15 @@ func buildJamfStaticComputerGroupStruct(d *schema.ResourceData) (*jamf.ComputerG
 		for _, c := range comps {
 			compData := c.(map[string]interface{})
 			comp := jamf.ComputerGroupComputerEntry{}
-			if val, ok := compData["id"].(int); ok {
-				comp.ID = val
-			}
 			if val, ok := compData["serial_number"].(string); ok {
 				comp.SerialNumber = val
 				if _, ok := compData["id"]; ok {
 					return nil, fmt.Errorf("must provide exactly one of \"serial_number\" or \"id\"")
 				}
+			} else if val, ok := compData["id"].(int); ok {
+				comp.ID = val
 			} else {
-				if _, ok := compData["id"]; !ok {
-					return nil, fmt.Errorf("must provide exactly one of \"serial_number\" or \"id\"")
-				}
+				return nil, fmt.Errorf("must provide exactly one of \"serial_number\" or \"id\"")
 			}
 			if val, ok := compData["name"].(string); ok {
 				comp.Name = val

--- a/jamf/resource_jamf_staticComputerGroup.go
+++ b/jamf/resource_jamf_staticComputerGroup.go
@@ -60,7 +60,7 @@ func resourceJamfStaticComputerGroup() *schema.Resource {
 						},
 						"serial_number": {
 							Type:     schema.TypeString,
-							Computed: true,
+							Optional: true,
 						},
 					},
 				},

--- a/jamf/resource_jamf_staticComputerGroup_test.go
+++ b/jamf/resource_jamf_staticComputerGroup_test.go
@@ -1,0 +1,55 @@
+package jamf
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccJamfStaticComputerGroup_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCheckJamfStaticComputerGroupConfigWithName,
+				ExpectError: regexp.MustCompile("Computed attributes cannot be set, but a value was set for \"computer.0.name\""),
+			},
+			{
+				Config:      testAccCheckJamfStaticComputerGroupConfigMissingSerial,
+				ExpectError: regexp.MustCompile("must provide exactly one of \"serial_number\" or \"id\""),
+			},
+			{
+				Config:      testAccCheckJamfStaticComputerGroupConfigWithSerialAndId,
+				ExpectError: regexp.MustCompile("must provide exactly one of \"serial_number\" or \"id\""),
+			},
+		},
+	})
+}
+
+const (
+	testAccCheckJamfStaticComputerGroupConfigWithName = `
+resource "jamf_staticComputerGroup" "test" {
+	name = "test"
+	computer {
+		name = "test-hostname"
+	}
+}`
+
+	testAccCheckJamfStaticComputerGroupConfigMissingSerial = `
+resource "jamf_staticComputerGroup" "test" {
+	name = "test"
+	computer {
+	}
+}`
+
+	testAccCheckJamfStaticComputerGroupConfigWithSerialAndId = `
+resource "jamf_staticComputerGroup" "test" {
+name = "test"
+computer {
+	id = 1
+	serial_number = "test-serial"
+}
+}`
+)


### PR DESCRIPTION
### Changes:

* `jamf_staticComputerGroup`'s `computer` attribute schema now allows for exactly one of `serial_number` or `id`.

The [example in docs](https://registry.terraform.io/providers/Yohan460/jamf/latest/docs/resources/staticComputerGroup) seems to imply that serial number may be used to assign a computer:

```hcl
resource "jamf_staticComputerGroup" "test_static_1" {
  computer {
    id = 1
  }
  computer {
    serial_number = "C06X4489JFD3"
  }
  name = "Test Static 1"
}
```

However, it's presently a computed value. Only the Jamf computer object's ID may be used. This change allows the use of serial number.

* `buildJamfStaticComputerGroupStruct` now returns an error if both (or neither) a `serial_number` and `id` are specified. 

I rolled custom validation in this func b/c: https://github.com/hashicorp/terraform-plugin-sdk/issues/644

* Added three simple test cases covering the new custom validation, jamf/resource_jamf_staticComputerGroup_test.go

* Fixed one simple bug in `make testacc` - incorrect gofmtcheck.sh path
* Fixed two simple bugs in jamf/resource_jamf_computer_extension_attribute_test.go and jamf/data_source_jamf_computer_extension_attribute.go: `data_type = "string"` -> `"String"`; `recon_display` missing from schemata.

There are two other bugs in jamf/resource_jamf_computer_extension_attribute_test.go, though I may just be holding it wrong. On the first run, this occurs:

```
panic: script: '': source data must be an array or slice, got map

goroutine 188 [running]:
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*ResourceData).Set(0x140005a5000, {0x100dd0abb, 0x6}, {0x10105afc0, 0x140000a86c0})
	/Users/w0de/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.4.3/helper/schema/resource_data.go:230 +0x24c
github.com/yohan460/terraform-provider-jamf/jamf.deconstructJamfComputerExtensionAttributeStruct(0x100e10ba9?, 0x1400054db80)
	/Users/w0de/src/terraform-provider-jamf/jamf/data_source_jamf_computer_extension_attribute.go:154 +0x4c4
github.com/yohan460/terraform-provider-jamf/jamf.resourceJamfComputerExtensionAttributeRead({0x140005a5000?, 0x100e10ba9?}, 0x140005a5000, {0x10117a720?, 0x14000304480})
	/Users/w0de/src/terraform-provider-jamf/jamf/resource_jamf_computer_extension_attribute.go:240 +0x19c
github.com/yohan460/terraform-provider-jamf/jamf.resourceJamfComputerExtensionAttributeCreate({0x10118f998, 0x140006fab60}, 0x0?, {0x10117a720?, 0x14000304480?})
	/Users/w0de/src/terraform-provider-jamf/jamf/resource_jamf_computer_extension_attribute.go:223 +0x158
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).create(0x140000fd5c0, {0x10118f928, 0x14000543630}, 0x2?, {0x10117a720, 0x14000304480})
	/Users/w0de/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.4.3/helper/schema/resource.go:285 +0x154
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).Apply(0x140000fd5c0, {0x10118f928, 0x14000543630}, 0x140006fa4d0, 0x14000780500, {0x10117a720, 0x14000304480})
	/Users/w0de/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.4.3/helper/schema/resource.go:396 +0x674
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ApplyResourceChange(0x1400053c318, {0x10118f928, 0x14000543630}, 0x14000543680)
	/Users/w0de/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.4.3/helper/schema/grpc_provider.go:955 +0x82c
github.com/hashicorp/terraform-plugin-go/tfprotov5/server.(*server).ApplyResourceChange(0x14000568b80, {0x10118f8f0?, 0x1400059eb70?}, 0x0?)
	/Users/w0de/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.2.1/tfprotov5/server/server.go:332 +0x64
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ApplyResourceChange_Handler({0x101140bc0?, 0x14000568b80}, {0x10118f8f0, 0x1400059eb70}, 0x140004d4660, 0x0)
	/Users/w0de/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.2.1/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:380 +0x164
google.golang.org/grpc.(*Server).processUnaryRPC(0x14000478000, {0x101193f90, 0x140001fc780}, 0x1400040a300, 0x1400055f260, 0x101745a60, 0x0)
	/Users/w0de/go/pkg/mod/google.golang.org/grpc@v1.35.0/server.go:1217 +0xa58
google.golang.org/grpc.(*Server).handleStream(0x14000478000, {0x101193f90, 0x140001fc780}, 0x1400040a300, 0x0)
	/Users/w0de/go/pkg/mod/google.golang.org/grpc@v1.35.0/server.go:1540 +0x7c4
google.golang.org/grpc.(*Server).serveStreams.func1.2()
	/Users/w0de/go/pkg/mod/google.golang.org/grpc@v1.35.0/server.go:878 +0x84
created by google.golang.org/grpc.(*Server).serveStreams.func1 in goroutine 184
	/Users/w0de/go/pkg/mod/google.golang.org/grpc@v1.35.0/server.go:876 +0x24c
FAIL	github.com/yohan460/terraform-provider-jamf/jamf	1.882s
FAIL
make: *** [testacc] Error 1
```

I'm not sure how to fix this yet. If its not just my mistake, lmk, I'll open an issue.

On a subsequent run, the test fails because the prior test did succeed in creating an extension attribute - but didn't destroy it. Jamf API returns a duplicate name error:

```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./jamf -v -count 1 -parallel 20 -run TestAccJamfComputerExtensionAttribute_basic -timeout 120m
=== RUN   TestAccJamfComputerExtensionAttribute_basic
=== PAUSE TestAccJamfComputerExtensionAttribute_basic
=== CONT  TestAccJamfComputerExtensionAttribute_basic
    resource_jamf_computer_extension_attribute_test.go:12: Step 1/3 error: Error running apply: exit status 1

        Error: API Error: 409 URI: /JSSResource/computerextensionattributes/id/0 Body: <html> <head>    <title>Status page</title> </head> <body style="font-family: sans-serif;"> <p style="font-size: 1.2em;font-weight: bold;margin: 1em 0px;">Conflict</p> <p>Error: Duplicate name</p> <p>You can get technical details <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.10">here</a>.<br> Please continue your visit at our <a href="/">home page</a>. </p> </body> </html>


--- FAIL: TestAccJamfComputerExtensionAttribute_basic (1.34s)
FAIL
FAIL	github.com/yohan460/terraform-provider-jamf/jamf	1.619s
FAIL
make: *** [testacc] Error 1
```